### PR TITLE
Open JSON API ports and avoid accidental deletions

### DIFF
--- a/terraform/redcraft-minecraft/redcraft-minecraft.tf
+++ b/terraform/redcraft-minecraft/redcraft-minecraft.tf
@@ -1,4 +1,8 @@
-resource "scaleway_instance_ip" "public_ip" {}
+resource "scaleway_instance_ip" "public_ip" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "scaleway_instance_security_group" "minecraft_security_group" {
   name = "redcraft-minecraft-${var.env_name}"
@@ -33,6 +37,10 @@ resource "scaleway_instance_volume" "minecraft_data" {
   size_in_gb = var.attached_disk_size
   type = "b_ssd"
   name = "redcraft-minecraft-${var.env_name}-data"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "scaleway_instance_server" "minecraft_instance" {

--- a/terraform/redcraft-minecraft/redcraft-minecraft.tf
+++ b/terraform/redcraft-minecraft/redcraft-minecraft.tf
@@ -16,6 +16,11 @@ resource "scaleway_instance_security_group" "minecraft_security_group" {
     action = "accept"
     port = "25565"
   }
+
+  inbound_rule {
+    action = "accept"
+    port = "25580"
+  }
 }
 
 data "scaleway_image" "minecraft_image" {

--- a/terraform/redcraft-mysql/redcraft-mysql.tf
+++ b/terraform/redcraft-mysql/redcraft-mysql.tf
@@ -1,4 +1,8 @@
-resource "scaleway_instance_ip" "public_ip" {}
+resource "scaleway_instance_ip" "public_ip" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "scaleway_instance_security_group" "mysql_security_group" {
   name = "redcraft-mysql-${var.env_name}"
@@ -29,6 +33,10 @@ resource "scaleway_instance_volume" "mysql_data" {
   size_in_gb = var.attached_disk_size
   type = "b_ssd"
   name = "redcraft-mysql-${var.env_name}-data"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "scaleway_instance_server" "mysql_instance" {

--- a/terraform/redcraft-redis/redcraft-redis.tf
+++ b/terraform/redcraft-redis/redcraft-redis.tf
@@ -1,4 +1,8 @@
-resource "scaleway_instance_ip" "public_ip" {}
+resource "scaleway_instance_ip" "public_ip" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "scaleway_instance_security_group" "redis_security_group" {
   name = "redcraft-redis-${var.env_name}"

--- a/terraform/redcraft-vpn/redcraft-vpn.tf
+++ b/terraform/redcraft-vpn/redcraft-vpn.tf
@@ -1,4 +1,8 @@
-resource "scaleway_instance_ip" "public_ip" {}
+resource "scaleway_instance_ip" "public_ip" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "scaleway_instance_security_group" "vpn_security_group" {
   name = "redcraft-vpn-${var.env_name}"


### PR DESCRIPTION
This PR opens the port 25580 for the proxy so we can access the following API endpoints:
http://proxy.production.redcraft.org:25580/players.json
http://proxy.production.redcraft.org:25580/versions.json

It also prevents public IPs and storage disks from being destroyed if we mistype terraform commands