### PR TITLE
Add Django terraform files

### DIFF
--- a/terraform/redcraft-django/production.tfvars
+++ b/terraform/redcraft-django/production.tfvars
@@ -1,0 +1,2 @@
+env_name = "production"
+instance_type = "DEV1-S"

--- a/terraform/redcraft-django/provider.tf
+++ b/terraform/redcraft-django/provider.tf
@@ -1,0 +1,21 @@
+provider "scaleway" {
+  access_key = var.scw_access_key
+  secret_key = var.scw_secret_key
+  organization_id = var.scw_default_organization_id
+  region = var.scw_default_region
+  zone = var.scw_default_zone
+}
+
+terraform {
+  backend "s3" {
+    bucket = "redcraft-terraform"
+    key = "django.tfstate"
+
+    region = "fr-par"
+
+    endpoint = "https://s3.fr-par.scw.cloud"
+
+    skip_credentials_validation = true
+    skip_region_validation = true
+  }
+}

--- a/terraform/redcraft-django/redcraft-django.tf
+++ b/terraform/redcraft-django/redcraft-django.tf
@@ -1,0 +1,40 @@
+resource "scaleway_instance_ip" "public_ip" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "scaleway_instance_security_group" "django_security_group" {
+  name = "redcraft-django-${var.env_name}"
+
+  inbound_default_policy = "drop"
+  outbound_default_policy = "accept"
+
+  inbound_rule {
+    action = "accept"
+    port = "22"
+    ip_range = "10.0.0.0/8"
+  }
+
+  inbound_rule {
+    action = "accept"
+    port = "80"
+  }
+}
+
+data "scaleway_image" "django_image" {
+  architecture = "x86_64"
+
+  name_filter = "redcraft-django-*"
+}
+
+resource "scaleway_instance_server" "django_instance" {
+  type  = var.instance_type
+  image = data.scaleway_image.django_image.id
+
+  name = "redcraft-django-${var.env_name}"
+
+  ip_id = scaleway_instance_ip.public_ip.id
+
+  security_group_id = scaleway_instance_security_group.django_security_group.id
+}

--- a/terraform/redcraft-django/staging.tfvars
+++ b/terraform/redcraft-django/staging.tfvars
@@ -1,0 +1,2 @@
+env_name = "staging"
+instance_type = "DEV1-S"

--- a/terraform/redcraft-django/testing.tfvars
+++ b/terraform/redcraft-django/testing.tfvars
@@ -1,0 +1,2 @@
+env_name = "testing"
+instance_type = "DEV1-S"

--- a/terraform/redcraft-django/variables.tf
+++ b/terraform/redcraft-django/variables.tf
@@ -1,0 +1,27 @@
+variable "scw_access_key" {
+  description = "SCW_ACCESS_KEY environment variable"
+}
+
+variable "scw_secret_key" {
+  description = "SCW_SECRET_KEY environment variable"
+}
+
+variable "scw_default_organization_id" {
+  description = "SCW_DEFAULT_ORGANIZATION_ID environment variable"
+}
+
+variable "scw_default_region" {
+  description = "SCW_DEFAULT_REGION environment variable"
+}
+
+variable "scw_default_zone" {
+  description = "SCW_DEFAULT_ZONE environment variable"
+}
+
+# Defined on a per environment basis in *.tfvars
+variable "env_name" {
+}
+
+variable "instance_type" {
+    default = "DEV1-S"
+}

--- a/terraform/redcraft-django/versions.tf
+++ b/terraform/redcraft-django/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    scaleway = {
+      source = "scaleway/scaleway"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This adds Django terraform files to deploy the main web servers.
It's already configured for the following 3 environments:
- testing
- staging
- production